### PR TITLE
fixed macro expansion when crystal spec is run.

### DIFF
--- a/src/temel.cr
+++ b/src/temel.cr
@@ -6,5 +6,5 @@ end
 # Since we are not able to pass params to macros, we must pass all tags explicitly.
 
 {% for html_tag in %w(a abbr address area article aside audio b base bdi bdo blockquote body br button canvas caption cite code col colgroup command datalist dd del details dfn div dl dt em embed fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header hgroup hr html i iframe img input ins kbd keygen label legend li link map mark menu meta meter nav noscript object ol optgroup option output p param pre progress q rp rt ruby s samp script section select small source span strong style sub summary sup table tbody td textarea tfoot th thead time title tr track u ul var video wbr) %}
-tag {{html_tag.id}}
+tag {{html_tag}}
 {% end %}

--- a/src/temel/macros.cr
+++ b/src/temel/macros.cr
@@ -6,37 +6,37 @@ macro attributes(list)
 end
 
 macro legalize_tag(name)
-  "#{ "{{name}}".gsub(/_/, '-') }"
+  "#{ "{{name.id}}".gsub(/_/, '-') }"
 end
 
 macro tag(name)
-  def {{name}}
-    "<#{ legalize_tag {{name.id}} } />"
+  def {{name.id}}
+    "<#{ legalize_tag {{name}} } />"
   end
-  def {{name}}(attrs : NamedTuple)
-    "<#{ legalize_tag {{name.id}} } #{attributes attrs} />"
+  def {{name.id}}(attrs : NamedTuple)
+    "<#{ legalize_tag {{name}} } #{attributes attrs} />"
   end
-  def {{name}}(content : String|Int)
-    "<#{ legalize_tag {{name.id}} }>#{content}</#{ legalize_tag {{name.id}} }>"
+  def {{name.id}}(content : String|Int)
+    "<#{ legalize_tag {{name}} }>#{content}</#{ legalize_tag {{name}} }>"
   end
 
   # Block Based DSL
-  def {{name}}(&block)
+  def {{name.id}}(&block)
     content = yield
     content = content.join "" if content.is_a? Array
-    "<#{ legalize_tag {{name.id}} }>#{content}</#{ legalize_tag {{name.id}} }>"
+    "<#{ legalize_tag {{name}} }>#{content}</#{ legalize_tag {{name}} }>"
   end
-  def {{name}}(attrs : NamedTuple, &block)
+  def {{name.id}}(attrs : NamedTuple, &block)
     content = yield
     content = content.join "" if content.is_a? Array
-    "<#{ legalize_tag {{name.id}} } #{attributes attrs}>#{content}</#{ legalize_tag {{name.id}} }>"
+    "<#{ legalize_tag {{name}} } #{attributes attrs}>#{content}</#{ legalize_tag {{name}} }>"
   end
 
   # Argument Based DSL
-  def {{name}}(*elements)
-    "<#{ legalize_tag {{name.id}} }>#{elements.join ""}</#{ legalize_tag {{name.id}} }>"
+  def {{name.id}}(*elements)
+    "<#{ legalize_tag {{name}} }>#{elements.join ""}</#{ legalize_tag {{name}} }>"
   end
-  def {{name}}(attrs : NamedTuple, *elements)
-    "<#{ legalize_tag {{name.id}} } #{attributes attrs}>#{elements.join ""}</#{ legalize_tag {{name.id}} }>"
+  def {{name.id}}(attrs : NamedTuple, *elements)
+    "<#{ legalize_tag {{name}} } #{attributes attrs}>#{elements.join ""}</#{ legalize_tag {{name}} }>"
   end
 end


### PR DESCRIPTION
`crystal spec` was failing to compile due to a name clash of the "select" method.  This commit changes the tag names to strings for macro expansion so that spec can compile correctly.

Let me know if this is acceptable or you want anything changed.